### PR TITLE
Linux add USE_SYSTEM_SDL MAKEFLAG (pkg-config)

### DIFF
--- a/syncscribble/Makefile
+++ b/syncscribble/Makefile
@@ -262,21 +262,31 @@ LIBS = ../SDL/build/build/.libs/libSDL2.a  ../SDL/build/build/.libs/libSDL2main.
 include Makefile.wasm
 
 else
-# Linux - uses SDL 2.0.10 (branch write-linux); see scribbleres/SDL-Makefile.unix
 
 SOURCES += linux/linuxtablet.c ../nanovgXC/glad/glad.c
-INCSYS += ../SDL/Release/include
-#INCFILES = ../scribbleres/force_link_glibc_2.14.h  -- doesn't work anymore, build in chroot instead
 DEFS += SCRIBBLE_TEST_PATH='"$(CURDIR)/../scribbletest"'
 DEBUG ?= 0
+USE_SYSTEM_SDL ?= 0
+ifneq ($(USE_SYSTEM_SDL),0)
+  # Linux - pass `USE_SYSTEM_SDL=1` to use the system SDL2 (via pkg-config Makefile.unix)
+  PKGS += sdl2
+else
+  # Linux - uses SDL 2.0.10 (branch write-linux); see scribbleres/SDL-Makefile.unix
+  INCSYS += ../SDL/Release/include
+  #INCFILES = ../scribbleres/force_link_glibc_2.14.h  -- doesn't work anymore, build in chroot instead
+  ifneq ($(DEBUG), 0)
+    LIBS = ../SDL/Debug/libSDL2d.a
+  else
+    # use $(BUILDDIR) to support Release and LinuxRel
+    LIBS = ../SDL/$(BUILDDIR)/libSDL2.a
+  endif
+endif
+
 ifneq ($(DEBUG), 0)
-  LIBS = ../SDL/Debug/libSDL2d.a
   # use asan by default for debug build
   SANITIZE = 1
-else
-  # use $(BUILDDIR) to support Release and LinuxRel
-  LIBS = ../SDL/$(BUILDDIR)/libSDL2.a
 endif
+
 # must use this instead of just -lpthread so the defines needed by force_glibc.h are created
 CFLAGS = -pthread
 # X11 and Xi needed for linuxtablet.c


### PR DESCRIPTION
Closes #2 

~I have not yet have time to validate that this does not break the existing build with the forked SDL2 nor have I tested `USE_SYSTEM_SDL=1` on a Distro other then NixOS.~


Build tested with `USE_SYSTEM_SDL=1` in a Debian 12 container and run on NixOS:
```
podman run -it docker.io/library/debian:stable
apt-get install --no-install-recommends build-essential curl git mercurial libx11-dev libxcb1-dev libudev-dev libdbus-1-dev libibus-1.0-dev libxcursor-dev libxinerama-dev libxi-dev libxrandr-dev libxss-dev libxxf86vm-dev libgl1-mesa-dev libegl1-mesa-dev libsdl2-dev libsdl2-2.0-0


cd  /tmp/
git clone --recurse-submodules https://github.com/lukts30/Write.git
cd Write
git switch sdl2

cd syncscribble && make DEBUG=0 USE_SYSTEM_SDL=1


 $ steam-run ldd Write 
linux-vdso.so.1 (0x00007ffe733cd000)
libX11.so.6 => /lib64/libX11.so.6 (0x00007f6613093000)
libXi.so.6 => /lib64/libXi.so.6 (0x00007f661307f000)
libSDL2-2.0.so.0 => /lib64/libSDL2-2.0.so.0 (0x00007f6612e00000)
libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f6612a00000)
libm.so.6 => /lib64/libm.so.6 (0x00007f6612d1d000)
libc.so.6 => /lib64/libc.so.6 (0x00007f6612813000)
libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f6613078000)
libxcb.so.1 => /lib64/libxcb.so.1 (0x00007f6612cf2000)
libXext.so.6 => /lib64/libXext.so.6 (0x00007f6612cdd000)
libXcursor.so.1 => /lib64/libXcursor.so.1 (0x00007f6612cd0000)
libXfixes.so.3 => /lib64/libXfixes.so.3 (0x00007f6612cc8000)
libXrandr.so.2 => /lib64/libXrandr.so.2 (0x00007f6612cbb000)
libXss.so.1 => /lib64/libXss.so.1 (0x00007f6613071000)
/lib64/ld-linux-x86-64.so.2 => /nix/store/y23k5nhvh8qxr62smy182f57zwhqg412-glibc-multi-2.39-52/lib/ld-linux-x86-64.so.2 (0x00007f661339b000)
libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f6612c96000)
libXau.so.6 => /nix/store/qx025bsivaryh9p248l8qybsdv9hp1nr-libXau-1.0.11/lib/libXau.so.6 (0x00007f6612c91000)
libXdmcp.so.6 => /nix/store/bkh4ymvswzmzh9dkvmpfkkpgnsi272bc-libXdmcp-1.1.5/lib/libXdmcp.so.6 (0x00007f6612c89000)
libXrender.so.1 => /lib64/libXrender.so.1 (0x00007f6612c7c000)
```

Build tested with `USE_SYSTEM_SDL=0` in a Debian 12 container and run on NixOS:
```
cd  /tmp/
git clone --recurse-submodules https://github.com/lukts30/Write.git Write2
cd Write
git switch sdl2

cd Write2
cd SDL
git switch write-linux
make -f ../scribbleres/SDL-Makefile.unix DEBUG=0 BUILDDIR=Release
# create symlink for missing include dir?
ln -s ../include/ Release/include
cd ..
cd syncscribble && make DEBUG=0 USE_SYSTEM_SDL=0
```