### PR TITLE
harden the make machinery

### DIFF
--- a/scribbleres/Makefile
+++ b/scribbleres/Makefile
@@ -15,4 +15,4 @@ res_strings.cpp: strings/*.xml
 	python3 embed.py --compress $^ > $@
 
 clean:
-	rm res_icons.cpp res_strings.cpp
+	rm -f res_icons.cpp res_strings.cpp


### PR DESCRIPTION
Harden the Make machiney by adding the option `-f` (`--force`) to `rm` at the `clean:` target of `scribbleres/Makefile`. This simple correction allows involved machineries (e.g., debhelp(7)) to work smoothly.